### PR TITLE
update STM32F4x1 pinout according to latest commit on blackmagic-debug/blackmagic

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,10 +62,8 @@ Connect a STM32F401 or STM32F411 Black Pill for upload:
 
 |Signal|Pin|
 |---|---|
-|SWDIO|A13|
-|SWCLK|A14|
-
-On some boards these pins are marked "SWDIO" and "SWSCK".
+|SWDIO|B9|
+|SWCLK|B8|
 
 ## Installation on other platforms
 


### PR DESCRIPTION
This pull request updates the pinout description for the STM32F401/STM32F411 black pill, as the pinout was changed in [f9e63b4](https://github.com/blackmagic-debug/blackmagic/commit/f9e63b47edbee4388d96d8943a1a238107bf4477). This commit fixed issue [1418](https://github.com/blackmagic-debug/blackmagic/issues/1418) on blackmagic-debug/blackmagic.

To be consistent, it would be good to update the pinout on this repository as well, which is done in this pull request.