### PR TITLE
add commit hash or tag to name of zipped folder

### DIFF
--- a/.github/workflows/build-current.yml
+++ b/.github/workflows/build-current.yml
@@ -53,6 +53,13 @@ jobs:
         with:
           repository: "blackmagic-debug/blackmagic"
 
+      - name: Get commit hash
+        id: getcommit
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Report commit hash
+        run: echo ${{ steps.getcommit.outputs.sha_short }}
+
       - uses: actions/checkout@v3
         with:
           path: "bmp"
@@ -77,7 +84,7 @@ jobs:
         run: unzip bmda.zip -d src/artifacts/hosted
 
       - name: Zip
-        run: ( ln -s src/artifacts blackmagic-firmware; zip -r9 blackmagic-firmware.zip blackmagic-firmware/ )
+        run: ( ln -s src/artifacts blackmagic-firmware-${{ steps.getcommit.outputs.sha_short }}; zip -r9 blackmagic-firmware.zip blackmagic-firmware-${{ steps.getcommit.outputs.sha_short }}/ )
 
       - name: Release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -98,7 +98,7 @@ jobs:
         run: unzip bmda.zip -d src/artifacts/hosted
 
       - name: Zip
-        run: ( ln -s src/artifacts blackmagic-firmware; zip -r9 blackmagic-firmware.zip blackmagic-firmware/ )
+        run: ( ln -s src/artifacts blackmagic-firmware-${{ steps.upstream.outputs.tag_name }}; zip -r9 blackmagic-firmware.zip blackmagic-firmware-${{ steps.upstream.outputs.tag_name }}/ )
 
       - name: Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
This pull request adds:
- tag to the name of the folder being zipped in the `build release` workflow
- short commit hash to the name of the folder being zipped in the `build current` workflow

This has the benefit that the commit/tag on which the build is based is clearly visible in the folder which is unzipped after downloading. This reduces the ambiguity on which commit the files downloaded are based.

The name of the file uploaded to the release page is not changed, as that would increase the number of release artifacts each time the workflow is run for another commit.